### PR TITLE
Fix regenerate test

### DIFF
--- a/pear/tests/test_regenerate.py
+++ b/pear/tests/test_regenerate.py
@@ -25,7 +25,7 @@ def test_regenerate(tmp_path_factory: pytest.TempPathFactory,
     with open(code_path, 'w') as f:
         f.write(BUGGY)
 
-    cmd = ['gcc', '-o', bin_path, code_path]
+    cmd = ['gcc', '-O0', '-o', bin_path, code_path]
     run_cmd(cmd)
     ir_cache_arg = []
     if ir_cache:


### PR DESCRIPTION
Was running the linux test suite, and found that the regenerate test was failing, because in initial compilation GCC was optimising the entire buggy binary content away before it gets patched.

Adding an O0 flag to the initial compilation appears to fix the issue, and get the test passing again.