### PR TITLE
Converted build_parser method of rewriters to classmethod

### DIFF
--- a/pear/rewriters/aflpp/aflpp_rewriter.py
+++ b/pear/rewriters/aflpp/aflpp_rewriter.py
@@ -66,10 +66,10 @@ class AFLPlusPlusRewriter(Rewriter):
             See the tests within PeAR for AFL++ rewriter for example usage.
         ''')
 
-    @staticmethod
-    def build_parser(parser: argparse._SubParsersAction):
-        parser = parser.add_parser(AFLPlusPlusRewriter.name(),
-                                   description=AFLPlusPlusRewriter.get_description(),
+    @classmethod
+    def build_parser(cls, parser: argparse._SubParsersAction):
+        parser = parser.add_parser(cls.name(),
+                                   description=cls.get_description(),
                                    formatter_class=argparse.RawTextHelpFormatter,
                                    help='Add AFL++ instrumentation')
 

--- a/pear/rewriters/debug_rewrite.py
+++ b/pear/rewriters/debug_rewrite.py
@@ -33,9 +33,9 @@ class DebugRewriter(Rewriter):
     Rewriter that doesn't apply any tranformation, just lifts the binary to IR
     before attempting to generate it.
     """
-    @staticmethod
-    def build_parser(parser: argparse._SubParsersAction):
-        parser = parser.add_parser(DebugRewriter.name(),
+    @classmethod
+    def build_parser(cls, parser: argparse._SubParsersAction):
+        parser = parser.add_parser(cls.name(),
                                    help='dbg')
 
         parser.add_argument(

--- a/pear/rewriters/identity.py
+++ b/pear/rewriters/identity.py
@@ -23,9 +23,9 @@ class IdentityRewriter(Rewriter):
     Rewriter that doesn't apply any tranformation, just lifts the binary to IR
     before attempting to generate it.
     """
-    @staticmethod
-    def build_parser(parser: argparse._SubParsersAction):
-        parser = parser.add_parser(IdentityRewriter.name(),
+    @classmethod
+    def build_parser(cls, parser: argparse._SubParsersAction):
+        parser = parser.add_parser(cls.name(),
                                    help='Parse then regenerate binary')
         parser.description = """\
 Lift binary to GTIRB IR then attempt to generate it.

--- a/pear/rewriters/regenerate.py
+++ b/pear/rewriters/regenerate.py
@@ -23,9 +23,9 @@ class RegenerateRewriter(Rewriter):
     """
     Rewriter that regenerates a binary from instrumented assembly source.
     """
-    @staticmethod
-    def build_parser(parser: argparse._SubParsersAction):
-        parser = parser.add_parser(RegenerateRewriter.name(),
+    @classmethod
+    def build_parser(cls, parser: argparse._SubParsersAction):
+        parser = parser.add_parser(cls.name(),
                                    help='Regenerate binary from instrumented assembly source')
         parser.description = textwrap.dedent("""\
             Regenerate binary from assembly source. Will attempt to regenerate binary with

--- a/pear/rewriters/rewriter.py
+++ b/pear/rewriters/rewriter.py
@@ -60,8 +60,8 @@ class Rewriter:
         """
         raise NotImplementedError
 
-    @staticmethod
-    def build_parser(parser: argparse._SubParsersAction):
+    @classmethod
+    def build_parser(cls, parser: argparse._SubParsersAction):
         """
         Set up arparse parser for rewriter-specific arguments.
         Method should add subparser parser to given main parser.

--- a/pear/rewriters/trace/trace_rewriter.py
+++ b/pear/rewriters/trace/trace_rewriter.py
@@ -58,9 +58,9 @@ class TraceRewriter(Rewriter):
     """
     This class implements tracing instrumentation on Linux binaries.
     """
-    @staticmethod
-    def build_parser(parser: argparse._SubParsersAction):
-        parser = parser.add_parser(TraceRewriter.name(),
+    @classmethod
+    def build_parser(cls, parser: argparse._SubParsersAction):
+        parser = parser.add_parser(cls.name(),
                                    description= "Add tracing instrumentation to Linux binaries.",
                                    help='Add coverage instrumentation')
         parser.add_argument(

--- a/pear/rewriters/winafl/winafl_rewriter.py
+++ b/pear/rewriters/winafl/winafl_rewriter.py
@@ -39,9 +39,9 @@ class WinAFLRewriter(Rewriter):
     """
     This class implements WinAFL instrumentation on x86 and x64 Windows binaries.
     """
-    @staticmethod
-    def build_parser(parser: argparse._SubParsersAction):
-        parser = parser.add_parser(WinAFLRewriter.name(),
+    @classmethod
+    def build_parser(cls, parser: argparse._SubParsersAction):
+        parser = parser.add_parser(cls.name(),
                                    description= "Add WinAFL instrumentation to 32-bit or 64-bit Windows binaries.",
                                    help='Add WinAFL instrumentation',
                                    add_help=False)


### PR DESCRIPTION
Sorry to pile on the PRs, just getting together various changes that are useful to have upstreamed - hopefully the last for now.

This converts the build_parser method of the rewriter class from a staticmethod to a classmethod, meaning it takes in the class as the first arguments.

Comes with advantages when trying to extend existing rewriters, such as extending the AFLPlusPlusRewriter to add more instrumentation. Having a classmethod with the parser generated of `cls.get_name()` allows both:
- a child class to override get_name to generate a distinct parser
- a child class to call super to reuse parent parsers options

Makes adding in a custom parser reusing the base AFL parser much easier.

I've run the linux test suite, and all looking good.
